### PR TITLE
Make plugin compatible with Webpack 5 #15

### DIFF
--- a/lib/DrupalLibrariesPlugin.js
+++ b/lib/DrupalLibrariesPlugin.js
@@ -1,5 +1,6 @@
 const path = require('path'),
   YAML = require('yaml'),
+  mkdirp = require('mkdirp'),
   DrupalLibraryEntryGenerator = require('./DrupalLibraryEntryGenerator'),
   DrupalLibraryFile = require('./DrupalLibraryFile'),
   DrupalLibraryMetadata = require('./DrupalLibraryMetadata'),
@@ -50,13 +51,13 @@ class DrupalLibrariesPlugin {
   apply(compiler) {
     // Prevents drupal library dependencies from being included.
     compiler.hooks.normalModuleFactory.tap('DrupalLibrariesPlugin', cmf => {
-      cmf.hooks.factory.tap("DrupalLibrariesPlugin", factory => (data, callback) => {
+      cmf.hooks.factorize.tapAsync("DrupalLibrariesPlugin", (data, callback) => {
         const result = this.opts.requirePattern.exec(data.request)
         if (result) {
           callback(null, new DrupalLibraryModule(result[1]))
         }
         else {
-          factory(data, callback)
+          return callback()
         }
       })
     })
@@ -155,16 +156,15 @@ class DrupalLibrariesPlugin {
         const content = YAML.stringify(file.content),
           targetPath = compilation.getPath(file.targetPath)
 
-        compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
-          if (err) {
-            throw reject(err.message)
-          }
+        mkdirp(path.dirname(targetPath)).then(() => {
           compiler.outputFileSystem.writeFile(targetPath, content, err => {
             if (err) {
               throw reject(err.message)
             }
             accept()
           })
+        }).catch((err) => {
+          throw reject(err.message)
         })
       }))
     })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "webpack"
   ],
   "dependencies": {
+    "mkdirp": "^1.0.4",
     "yaml": "^1.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,6 +3215,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This PR makes the plugin compatible with Webpack 5 by switching to `compiler.factorize`. Also a new package (`mkdirp`) was needed since creating new new directories via `outputFileSystem.mkdirp` doesn't work anymore.