### PR TITLE
Remove deprecated named export, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 This plugin generates a Drupal asset library file based on a webpack build.
 
+It requires webpack 5 to work. For webpack 4 use the `1.x` version of this plugin.
+
 <h2 align="center">Install</h2>
 
 ```bash
@@ -24,6 +26,8 @@ npm install --save-dev drupal-libraries-webpack-plugin
 **webpack.config.js**
 
 ```js
+const DrupalLibrariesPlugin = require('drupal-libraries-webpack-plugin');
+
 module.exports = {
   plugins: [
   	new DrupalLibrariesPlugin()
@@ -73,7 +77,7 @@ Split a library into multiple library files.
 module.exports = {
   plugins: [
   	new DrupalLibrariesPlugin({
-  	  	
+
   	  path: (library, metadata) => {
   	    const lib1 = new DrupalLibraryFile('a.libraries.yml'),
   	    	lib2 = new DrupalLibraryFile('webpack.libraries.yml')
@@ -86,7 +90,7 @@ module.exports = {
   	        lib2.add(name, library, metadata)
   	      }
   	    })
-  	    
+
   	    return [lib1, lib2]
   	  }
   	})
@@ -184,7 +188,7 @@ class StaticVersionLibraryGenerator extends DrupalLibraryEntryGenerator {
   constructor(version) {
     this.version = version
   }
-  
+
   async versionGenerator(metadata) {
     return this.version
   }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 exports = module.exports = require('./lib/DrupalLibrariesPlugin')
 
-// @deprecated: remove in 2.x
-exports.DrupalLibrariesPlugin = require('./lib/DrupalLibrariesPlugin')
-
 exports.DrupalLibraryMetadata = require('./lib/DrupalLibraryMetadata')
 exports.DrupalLibraryEntryGenerator = require('./lib/DrupalLibraryEntryGenerator')
 exports.DrupalLibraryFile = require('./lib/DrupalLibraryFile')
-exports.DrupalLibraryModule = require('./lib/DrupalLibraryFile')
+exports.DrupalLibraryModule = require('./lib/DrupalLibraryModule')

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -1,6 +1,6 @@
 const path = require('path'),
   MiniCssExtractPlugin = require('mini-css-extract-plugin'),
-  DrupalLibrariesPlugin = require('../').DrupalLibrariesPlugin,
+  DrupalLibrariesPlugin = require('../'),
   runWebpack = require('./lib/webpack-wrapper')
 
 test('Adds css assets to libraries', async () => {

--- a/test/drupal-library-module-unit.test.js
+++ b/test/drupal-library-module-unit.test.js
@@ -1,4 +1,4 @@
-const DrupalLibraryModule = require('../lib/DrupalLibraryModule')
+const DrupalLibraryModule = require('../').DrupalLibraryModule
 
 test('DrupalLibraryModule instantiates without error', async () => {
   await expect(() => new DrupalLibraryModule()).not.toThrow()

--- a/test/lib/webpack-wrapper.js
+++ b/test/lib/webpack-wrapper.js
@@ -1,6 +1,6 @@
 const webpack = require('webpack'),
   path = require('path'),
-  DrupalLibrariesPlugin = require('../../').DrupalLibrariesPlugin
+  DrupalLibrariesPlugin = require('../../')
 
 module.exports = async (webpackOpts, pluginOpts, extraPlugins) => {
   extraPlugins = extraPlugins || []

--- a/test/plugin-unit.test.js
+++ b/test/plugin-unit.test.js
@@ -1,4 +1,4 @@
-const DrupalLibrariesPlugin = require('../').DrupalLibrariesPlugin,
+const DrupalLibrariesPlugin = require('../'),
   DrupalLibraryEntryGenerator = require('../').DrupalLibraryEntryGenerator
 
 test('Default name generator handles invalid library names', async () => {


### PR DESCRIPTION
- In preparation for 2.x, remove deprecated named `DrupalLibrariesPlugin` export. It is now the default export.
- Update README file. Note that webpack 4 will not be supported in 2.x.