### PR TITLE
Fix external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module.exports = {
   plugins: [
   	new DrupalLibrariesPlugin({
   	  // Only pick up require('jquery') or require('Drupal') statements.
-  	  libraryPattern: /^(jquery|Drupal)$/
+  	  requirePattern: /^(jquery|Drupal)$/
   	})
   ],
 };

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const DrupalLibrariesPlugin = require('drupal-libraries-webpack-plugin');
 
 module.exports = {
   plugins: [
-  	new DrupalLibrariesPlugin()
+    new DrupalLibrariesPlugin()
   ],
 };
 ```
@@ -43,6 +43,14 @@ You can explicitly add a Drupal library dependency to module by using a special 
 
 ```js
 require('@drupal(core/jquery)')
+```
+
+Drupal libraries must be added as [external dependencies](https://webpack.js.org/configuration/externals/) in your webpack configuration:
+
+```js
+externals: {
+  '@drupal(drupal/core)': 'Drupal'
+}
 ```
 
 ### Configuration

--- a/lib/DrupalLibrariesPlugin.js
+++ b/lib/DrupalLibrariesPlugin.js
@@ -49,19 +49,6 @@ class DrupalLibrariesPlugin {
    *   The webpack compiler.
    */
   apply(compiler) {
-    // Prevents drupal library dependencies from being included.
-    compiler.hooks.normalModuleFactory.tap('DrupalLibrariesPlugin', cmf => {
-      cmf.hooks.factorize.tapAsync("DrupalLibrariesPlugin", (data, callback) => {
-        const result = this.opts.requirePattern.exec(data.request)
-        if (result) {
-          callback(null, new DrupalLibraryModule(result[1]))
-        }
-        else {
-          return callback()
-        }
-      })
-    })
-
     // Analyzes the final chunks to determine library dependencies.
     compiler.hooks.done.tapPromise('DrupalLibrariesPlugin', async stats => {
       this.metadata = await this._generateLibraryMetadata(stats.compilation)

--- a/test/library-dependency.test.js
+++ b/test/library-dependency.test.js
@@ -6,6 +6,9 @@ test('Generates a library entry for @drupal(core/drupal)', async () => {
     entry: {
       'require-drupal': path.resolve(__dirname, './fixtures/require-drupal.es6.js'),
     },
+    externals: {
+      '@drupal(drupal/core)': 'Drupal'
+    }
   })).result
 
   expect(result).toEqual({


### PR DESCRIPTION
- Remove hook that filters out Drupal library dependencies. It prevented missing dependency errors, but also broke external Drupal dependencies in the compiled code.
- You must add Drupal dependencies as [externals](https://webpack.js.org/configuration/externals/). See Readme.
