### PR TITLE
DC-909: Do not set version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ module.exports = {
   	    file.content['external'] = {
   	      remote: 'https://external-library.js',
   	    }
-  	    return DupalLibrariesPlugin.defaults.prepareFile(file, compiler, compilation)
+  	    return DrupalLibrariesPlugin.defaults.prepareFile(file, compiler, compilation)
   	  },
   	})
   ],

--- a/lib/DrupalLibraryEntryGenerator.js
+++ b/lib/DrupalLibraryEntryGenerator.js
@@ -17,7 +17,9 @@ module.exports = class LibraryEntryGenerator {
     const promises = [], library = {}
 
     promises.push(this.versionGenerator(metadata).then(version => {
-      library['version'] = version
+      if (version) {
+        library['version'] = version
+      }
     }))
 
     if (metadata.hasItems('css')) {
@@ -39,17 +41,18 @@ module.exports = class LibraryEntryGenerator {
     }
 
     await Promise.all(promises)
- 
+
     return library
   }
 
   /**
-   * Generates the version entry for a Drupal library entry.
+   * Generate a version for a Drupal library entry. Does nothing by default.
+   * Use `libraryEntryGenerator` option to set a version number.
    *
    * @param {DrupalLibraryMetadata} metadata
    */
   async versionGenerator(metadata) {
-    return '1.x'
+    return false
   }
 
 

--- a/test/async-split.test.js
+++ b/test/async-split.test.js
@@ -16,7 +16,7 @@ test('Tracks a shared synchronous webpack split', async () => {
   })).result
 
   expect(result).toEqual({
-    imports1: { version: '1.x', js: { 'imports1.js': {} } },
-    imports2: { version: '1.x', js: { 'imports2.js': {} } },
+    imports1: { js: { 'imports1.js': {} } },
+    imports2: { js: { 'imports2.js': {} } },
   })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -9,7 +9,7 @@ test('Tracks a single entrypoint', async () => {
   })).result
 
   await expect(result).toEqual({
-    a: { version: '1.x', js: { 'a.js': {} } },
+    a: { js: { 'a.js': {} } },
   })
 })
 
@@ -22,7 +22,7 @@ test('Tracks a multiple entrypoints', async () => {
   })).result
 
   await expect(result).toEqual({
-    a: { version: '1.x', js: { 'a.js': {} } },
-    b: { version: '1.x', js: { 'b.js': {} } },
+    a: { js: { 'a.js': {} } },
+    b: { js: { 'b.js': {} } },
   })
 })

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -28,7 +28,6 @@ test('Adds css assets to libraries', async () => {
 
   expect(result).toEqual({
     'css-include': {
-      version: '1.x',
       css: { theme: { 'css-include.css': {} } },
       js: { 'css-include.js': {} },
     },

--- a/test/library-dependency.test.js
+++ b/test/library-dependency.test.js
@@ -13,7 +13,6 @@ test('Generates a library entry for @drupal(core/drupal)', async () => {
 
   expect(result).toEqual({
     'require-drupal': {
-      version: '1.x',
       js: { 'require-drupal.js': {} },
       dependencies: [ 'drupal/core' ],
     },

--- a/test/library-entry-generator.test.js
+++ b/test/library-entry-generator.test.js
@@ -1,0 +1,28 @@
+const path = require('path'),
+  runWebpack = require('./lib/webpack-wrapper'),
+  { DrupalLibraryEntryGenerator } = require('../')
+
+  class StaticVersionLibraryGenerator extends DrupalLibraryEntryGenerator {
+    constructor(version) {
+      super();
+      this.version = version
+    }
+
+    async versionGenerator(metadata) {
+      return this.version
+    }
+  }
+
+test('Extend the default library entry with a version number', async () => {
+  const result = (await runWebpack({
+    entry: {
+      'a': path.resolve(__dirname, './fixtures/a.es6.js'),
+    },
+  }, {
+    libraryEntryGenerator: new StaticVersionLibraryGenerator('2.0'),
+  })).result
+
+  await expect(result).toEqual({
+    a: { version: '2.0', js: { 'a.js': {} } },
+  })
+})

--- a/test/sync-split.test.js
+++ b/test/sync-split.test.js
@@ -22,9 +22,9 @@ test('Tracks a shared synchronous webpack split', async () => {
   })).result
 
   expect(result).toEqual({
-    requires1: { version: '1.x', js: { 'requires1.js': {} }, dependencies: ['commons'] },
-    requires2: { version: '1.x', js: { 'requires2.js': {} }, dependencies: ['commons'] },
-    commons: { version: '1.x', js: { 'commons.js': {} } },
+    requires1: { js: { 'requires1.js': {} }, dependencies: ['commons'] },
+    requires2: { js: { 'requires2.js': {} }, dependencies: ['commons'] },
+    commons: { js: { 'commons.js': {} } },
   })
 })
 
@@ -49,9 +49,9 @@ test('Tracks a shared synchronous webpack split using importfrom', async () => {
   })).result
 
   expect(result).toEqual({
-    importsfrom1: { version: '1.x', js: { 'importsfrom1.js': {} }, dependencies: ['commons'] },
-    importsfrom2: { version: '1.x', js: { 'importsfrom2.js': {} }, dependencies: ['commons'] },
-    commons: { version: '1.x', js: { 'commons.js': {} } },
+    importsfrom1: { js: { 'importsfrom1.js': {} }, dependencies: ['commons'] },
+    importsfrom2: { js: { 'importsfrom2.js': {} }, dependencies: ['commons'] },
+    commons: { js: { 'commons.js': {} } },
   })
 })
 
@@ -67,8 +67,8 @@ test('Tracks a shared runtime chunk', async () => {
   })).result
 
   expect(result).toEqual({
-    a: { version: '1.x', js: { 'a.js': {} }, dependencies: ['runtime'] },
-    b: { version: '1.x', js: { 'b.js': {} }, dependencies: ['runtime'] },
-    runtime: { version: '1.x', js: { 'runtime.js': {} } }
+    a: { js: { 'a.js': {} }, dependencies: ['runtime'] },
+    b: { js: { 'b.js': {} }, dependencies: ['runtime'] },
+    runtime: { js: { 'runtime.js': {} } }
   })
 })


### PR DESCRIPTION
Currently the library sets a default version of `1.x` on every library generated in the libraries yaml file. This changes the default behavior to _not_ set any default version. As before, you can configure your version number with the `libraryEntryGenerator` option.

This will be a major release as it is a breaking change.